### PR TITLE
switch to the new price data format from chain storage and fix fee location

### DIFF
--- a/src/common/turingAdapter.js
+++ b/src/common/turingAdapter.js
@@ -59,8 +59,8 @@ class TuringAdapter {
           const foundTaskEvents = _.filter(_.map(events, ({ phase, event: { data, method, section } }) => {
             if (section === 'automationPrice') { // TaskScheduled, TaskExecuted, TaskCancelled events contain the same data for now
               console.log('Found task event', phase.toHuman(), `${section}.${method} ${data.toString()}`);
-              const eventData = data.toHuman(); // {who: '6757gffjjMc7E4sZJtkfvq8fmMzH2NPRrEL3f3tqpr2PzXYq', taskId: '1775-0-1'}
-              return { section, method, data: { ownerId: eventData.who, taskId: eventData.taskId } };
+              const eventData = data.toHuman(); // {ownerId: '6757gffjjMc7E4sZJtkfvq8fmMzH2NPRrEL3f3tqpr2PzXYq', taskId: '1775-0-1'}
+              return { section, method, data: { ownerId: eventData.ownerId, taskId: eventData.taskId } };
             }
 
             return undefined;
@@ -87,7 +87,7 @@ class TuringAdapter {
         // console.log('values[0][1].toHuman()', values[0][1].toHuman());
         const keyObj = values[0][0].toHuman();
         const priceObj = values[0][1].toHuman();
-        cb({ price: priceObj.amount, symbols: keyObj[2] });
+        cb({ price: priceObj.value, symbols: keyObj[2] });
       } catch (ex) {
         console.log('subscribePrice exception', ex);
       }
@@ -106,7 +106,7 @@ class TuringAdapter {
             if (section === 'automationPrice' && method === 'AssetUpdated' && phase.toHuman()?.ApplyExtrinsic === '2') {
               console.log('Found price event', phase.toHuman(), `${section}.${method} ${data.toString()}`);
 
-              const eventData = data.toHuman(); // {who: '66RxduFvFDjfQjYJRnX4ywgYm6w2SAiHqtqGKgY1qdfYCj3g', chain: 'shibuya', exchange: 'arthswap', asset1: 'WRSTR', asset2: 'USDC', price: '80' }
+              const eventData = data.toHuman(); // {ownerId: '66RxduFvFDjfQjYJRnX4ywgYm6w2SAiHqtqGKgY1qdfYCj3g', chain: 'shibuya', exchange: 'arthswap', asset1: 'WRSTR', asset2: 'USDC', price: '80' }
               return { section, method, data: { price: eventData.price, symbols: [eventData.asset1, eventData.asset2] } };
             }
 

--- a/src/components/AutomationPrice.jsx
+++ b/src/components/AutomationPrice.jsx
@@ -176,7 +176,9 @@ function AutomationTimeComponent() {
         proofSize: taskEncodedCallWeight.proofSize.add(astarInstrcutionWeight.proofSize.muln(instructionCountOnTuring)),
       };
       const fee = await parachainApi.call.transactionPaymentApi.queryWeightToFee(taskOverallWeight);
-      const scheduleFeeLocation = { V3: { parents: 1, interior: { X1: { Parachain: parachainParaId } } } };
+
+      const scheduleFeeLocation = { parents: 1, interior: { X1: { Parachain: parachainParaId } } };
+
       const executionFee = { assetLocation: { V3: { parents: 1, interior: { X1: { Parachain: parachainParaId } } } }, amount: fee };
       const rocstarLocation = { parents: 1, interior: { X1: { Parachain: parachainParaId } } };
 


### PR DESCRIPTION
We had change the storage layout of the structure in our lastest code on master at this moment so update accordingly.

- price -> value in Price structure
- who -> ownerId in our event and data

also, fix a xcm schedule feelocation, it was being send as `{V3: { V3: ..location }}` where it should be `{V3: location ...}`

After this change we will be able to schedule jobs again and seeing the token withdrawl from the right proxy account with right id.

<img width="657" alt="Screenshot 2023-10-23 at 9 46 05 AM" src="https://github.com/OAK-Foundation/automation-price-demo/assets/49754/09a2960b-5c37-4d0b-aaef-d5dc17b47f76">

